### PR TITLE
Editable Refinement Tracking

### DIFF
--- a/trans_lib/doc_corrector.py
+++ b/trans_lib/doc_corrector.py
@@ -6,35 +6,39 @@ from loguru import logger
 
 from trans_lib.enums import DocumentType, Language
 from trans_lib.errors import CorrectingTranslationError
-from trans_lib.helpers import analyze_document_type, calculate_checksum
+from trans_lib.helpers import analyze_document_type
 from trans_lib.trans_db import do_translation_correspond_to_source
 from trans_lib.translator_corrector import correct_chunk_translation
 
-def correct_jupyter_notebook_translation(root_path: Path, tgt_path: Path, tgt_lang: Language, src_lang: Language) -> None:
+def correct_jupyter_notebook_translation(root_path: Path, tgt_path: Path, tgt_lang: Language, src_lang: Language) -> bool:
     nb = jupytext.read(tgt_path)
+    res = False
     for i in range(len(nb.cells)):
-        correct_jupyter_cell(root_path, nb.cells[i], tgt_lang, src_lang)
+        res = correct_jupyter_cell(root_path, nb.cells[i], tgt_lang, src_lang) or res 
+    logger.debug(f"Res {res}")
+    return res
 
-def correct_jupyter_cell(root_path: Path, cell: dict, target_language: Language, source_language: Language) -> None:
+def correct_jupyter_cell(root_path: Path, cell: dict, target_language: Language, source_language: Language) -> bool:
     tgt_txt = cell["source"]
     metadata = cell.get("metadata")
     if metadata is None:
-        return
+        return False
     src_checksum = metadata.get("src_checksum")
     if src_checksum is None:
-        return
+        return False
     logger.debug("found metadata src_checksum")
 
     if do_translation_correspond_to_source(root_path, src_checksum, source_language, tgt_txt, target_language):
-        return
+        return False
     correct_chunk_translation(root_path, src_checksum, source_language, tgt_txt, target_language)
+    return True
     
-def correct_file_translation(root_path: Path, translated_file_path: Path, translate_lang: Language, source_language: Language) -> None:
+def correct_file_translation(root_path: Path, translated_file_path: Path, translate_lang: Language, source_language: Language) -> bool:
     doc_type = analyze_document_type(translated_file_path)
     logger.trace(doc_type)
     try:
         if doc_type == DocumentType.Markdown or doc_type == DocumentType.JupyterNotebook:
-            correct_jupyter_notebook_translation(root_path, translated_file_path, translate_lang, source_language)
+            return correct_jupyter_notebook_translation(root_path, translated_file_path, translate_lang, source_language)
         else:
             # TODO: proper chunking
             # TODO: DB saving

--- a/trans_lib/doc_corrector.py
+++ b/trans_lib/doc_corrector.py
@@ -1,0 +1,43 @@
+
+from pathlib import Path
+
+import jupytext
+from loguru import logger
+
+from trans_lib.enums import DocumentType, Language
+from trans_lib.errors import CorrectingTranslationError
+from trans_lib.helpers import analyze_document_type, calculate_checksum
+from trans_lib.trans_db import do_translation_correspond_to_source
+from trans_lib.translator_corrector import correct_chunk_translation
+
+def correct_jupyter_notebook_translation(root_path: Path, tgt_path: Path, tgt_lang: Language, src_lang: Language) -> None:
+    nb = jupytext.read(tgt_path)
+    for i in range(len(nb.cells)):
+        correct_jupyter_cell(root_path, nb.cells[i], tgt_lang, src_lang)
+
+def correct_jupyter_cell(root_path: Path, cell: dict, target_language: Language, source_language: Language) -> None:
+    tgt_txt = cell["source"]
+    metadata = cell.get("metadata")
+    if metadata is None:
+        return
+    src_checksum = metadata.get("src_checksum")
+    if src_checksum is None:
+        return
+    logger.debug("found metadata src_checksum")
+
+    if do_translation_correspond_to_source(root_path, src_checksum, source_language, tgt_txt, target_language):
+        return
+    correct_chunk_translation(root_path, src_checksum, source_language, tgt_txt, target_language)
+    
+def correct_file_translation(root_path: Path, translated_file_path: Path, translate_lang: Language, source_language: Language) -> None:
+    doc_type = analyze_document_type(translated_file_path)
+    logger.trace(doc_type)
+    try:
+        if doc_type == DocumentType.Markdown or doc_type == DocumentType.JupyterNotebook:
+            correct_jupyter_notebook_translation(root_path, translated_file_path, translate_lang, source_language)
+        else:
+            # TODO: proper chunking
+            # TODO: DB saving
+            raise NotImplementedError
+    except IOError as e:
+        raise CorrectingTranslationError(f"Failed to write corrected file {translated_file_path}: {e}", original_exception=e)

--- a/trans_lib/doc_translator.py
+++ b/trans_lib/doc_translator.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from .enums import DocumentType, Language
 from .translator import translate_contents_async
 from .helpers import read_string_from_file, analyze_document_type
@@ -23,10 +24,10 @@ async def translate_file_to_file_async(
 ) -> None:
     """Translates a file and writes the result to another file asynchronously."""
     doc_type = analyze_document_type(source_path)
-    print(doc_type)
+    logger.trace(doc_type)
     try:
         if doc_type == DocumentType.Markdown or doc_type == DocumentType.JupyterNotebook:
-            print("translate in this wat")
+            logger.trace("translate in this wat")
             await translate_notebook_async(root_path, source_path, source_language, target_path, target_language)
         else:
             # TODO: proper chunking

--- a/trans_lib/doc_translator_mod/notebook_file_translator.py
+++ b/trans_lib/doc_translator_mod/notebook_file_translator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from trans_lib.translator_retrieval import translate_chunk_or_retrieve_from_db_async
 from ..enums import Language
-from ..helpers import read_string_from_file
+from ..helpers import calculate_checksum, read_string_from_file
 from ..translator import _prepare_prompt_for_language, _ask_gemini_model, translate_chunk_with_prompt
 import jupytext
 import hashlib
@@ -20,8 +20,7 @@ async def translate_notebook_async(root_path: Path, source_file_path: Path, sour
 async def translate_jupyter_cell_async(root_path: Path, cell: dict, source_language: Language, target_language: Language) -> dict:
     src_txt = cell["source"]
     cell_type = cell["cell_type"]
-    checksum = hashlib.md5(src_txt.encode()).hexdigest()
-    # TODO: verify that current checksum isn't in the database
+    checksum = calculate_checksum(src_txt)
 
     cell["metadata"].setdefault("tags", [])
     cell["metadata"]["tags"].append("needs_review")

--- a/trans_lib/errors.py
+++ b/trans_lib/errors.py
@@ -140,15 +140,28 @@ class TranslationProcessError(TranslateFileError):
         super().__init__(message)
         self.original_exception = original_exception
        
-class CorrectTranslationError(Exception):
+class CorrectTranslationError(ProjectError):
     """
     Errors when correcting translation
     """
     pass
+
 class CorrectingTranslationError(CorrectTranslationError):
+    """
+    Correcting translation error
+    """
     def __init__(self, message: str, original_exception: Optional[Exception] = None):
         super().__init__(message)
         self.original_exception = original_exception
 
 class ChecksumNotFoundError(CorrectTranslationError):
+    """
+    Checksum not found in the database
+    """
+    pass
+
+class NoSourceFileError(CorrectTranslationError):
+    """
+    No source file for the given translated file
+    """
     pass

--- a/trans_lib/errors.py
+++ b/trans_lib/errors.py
@@ -145,5 +145,10 @@ class CorrectTranslationError(Exception):
     Errors when correcting translation
     """
     pass
+class CorrectingTranslationError(CorrectTranslationError):
+    def __init__(self, message: str, original_exception: Optional[Exception] = None):
+        super().__init__(message)
+        self.original_exception = original_exception
+
 class ChecksumNotFoundError(CorrectTranslationError):
     pass

--- a/trans_lib/errors.py
+++ b/trans_lib/errors.py
@@ -139,3 +139,11 @@ class TranslationProcessError(TranslateFileError):
     def __init__(self, message: str, original_exception: Optional[Exception] = None):
         super().__init__(message)
         self.original_exception = original_exception
+       
+class CorrectTranslationError(Exception):
+    """
+    Errors when correcting translation
+    """
+    pass
+class ChecksumNotFoundError(CorrectTranslationError):
+    pass

--- a/trans_lib/project_config_models.py
+++ b/trans_lib/project_config_models.py
@@ -190,12 +190,12 @@ class ProjectConfig(BaseModel):
             raise AddTranslatableFileError(FileDoesNotExistError(f"File not found in source directory: {path}"))
 
 
-    def get_translatable_files_paths(self) -> List[Path]:
-        """Gets a list of paths for all translatable files in the source directory."""
+    def get_translatable_files(self) -> List[FileModel]:
+        """Gets a list of all the translatable files in the source directory."""
         if not self.src_dir:
             return [] 
 
-        translatable_files: List[Path] = []
+        translatable_files: List[FileModel] = []
         
         from collections import deque 
         
@@ -206,11 +206,16 @@ class ProjectConfig(BaseModel):
             current_dir = queue.popleft()
             for file_obj in current_dir.files:
                 if file_obj.is_translatable():
-                    translatable_files.append(file_obj.path)
+                    translatable_files.append(file_obj)
             for sub_dir_obj in current_dir.dirs:
                 queue.append(sub_dir_obj)
                 
         return translatable_files
+
+    def get_translatable_files_paths(self) -> List[Path]:
+        """Gets a list of paths for all translatable files in the source directory."""
+        translatable_file = self.get_translatable_files() 
+        return [file.get_path() for file in translatable_file]
 
 
 def compare_and_submit_dir_structures(old_dir: DirectoryModel, new_dir: DirectoryModel) -> DirectoryModel:

--- a/trans_lib/project_manager.py
+++ b/trans_lib/project_manager.py
@@ -30,6 +30,7 @@ from .errors import (
 )
 
 
+# TODO: add refine translation command
 
 class Project:
     """Manages a translation project."""

--- a/trans_lib/trans_db.py
+++ b/trans_lib/trans_db.py
@@ -38,7 +38,7 @@ def add_contents_to_db(root_path: Path, contents: str, lang: Language) -> str:
 
 def read_contents_by_checksum_with_lang(root_path: Path, checksum: str, lang: Language) -> str | None:
     """
-    Looks for a file with the given checksum in the directory of the given lanaguage and returns its contents if it finds such file and None if it doesn't
+    Looks for a file with the given checksum in the directory of the given language and returns its contents if it finds such file and None if it doesn't
 
     Note: better performance then a usual [read_contents_by_checksum]
     """

--- a/trans_lib/trans_db.py
+++ b/trans_lib/trans_db.py
@@ -203,7 +203,7 @@ def do_translation_correspond_to_source(root_path: Path, src_checksum: str, src_
     Returns true if the given translation corresponds to the given source checksum and false otherwise
     """
     tgt_checksum = calculate_checksum(tgt_contents)
-    return do_translation_checksum_correspond_to_source(root_path, src_checksum, src_lang, tgt_contents, tgt_lang)
+    return do_translation_checksum_correspond_to_source(root_path, src_checksum, src_lang, tgt_checksum, tgt_lang)
 
 def set_checksum_pair_to_correspondence_db(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> None:
     if src_lang == tgt_lang:

--- a/trans_lib/trans_db.py
+++ b/trans_lib/trans_db.py
@@ -186,6 +186,18 @@ def find_correspondent_checksum(root_path: Path, src_checksum: str, src_lang: La
 
     return None
 
+def do_translation_correspond_to_source(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> bool:
+    """
+    Returns true if two given checksums of two different languages correspond (i.e the one is a translation of the other) and False otherwise
+    """
+    if tgt_lang == src_lang:
+        return False
+    true_tgt_checksum = find_correspondent_checksum(root_path, src_checksum, src_lang, tgt_lang)
+    if true_tgt_checksum is None:
+        return False
+
+    return true_tgt_checksum == tgt_checksum
+
 def set_checksum_pair_to_correspondence_db(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> None:
     if src_lang == tgt_lang:
         return None

--- a/trans_lib/trans_db.py
+++ b/trans_lib/trans_db.py
@@ -186,7 +186,7 @@ def find_correspondent_checksum(root_path: Path, src_checksum: str, src_lang: La
 
     return None
 
-def do_translation_correspond_to_source(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> bool:
+def do_translation_checksum_correspond_to_source(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> bool:
     """
     Returns true if two given checksums of two different languages correspond (i.e the one is a translation of the other) and False otherwise
     """
@@ -197,6 +197,13 @@ def do_translation_correspond_to_source(root_path: Path, src_checksum: str, src_
         return False
 
     return true_tgt_checksum == tgt_checksum
+
+def do_translation_correspond_to_source(root_path: Path, src_checksum: str, src_lang: Language, tgt_contents: str, tgt_lang: Language) -> bool:
+    """
+    Returns true if the given translation corresponds to the given source checksum and false otherwise
+    """
+    tgt_checksum = calculate_checksum(tgt_contents)
+    return do_translation_checksum_correspond_to_source(root_path, src_checksum, src_lang, tgt_contents, tgt_lang)
 
 def set_checksum_pair_to_correspondence_db(root_path: Path, src_checksum: str, src_lang: Language, tgt_checksum: str, tgt_lang: Language) -> None:
     if src_lang == tgt_lang:

--- a/trans_lib/trans_db.py
+++ b/trans_lib/trans_db.py
@@ -153,7 +153,18 @@ def remove_language_from_correspondence_db(root_path: Path, lang: Language) -> N
 
 def find_correspondent_checksum(root_path: Path, src_checksum: str, src_lang: Language, tgt_lang: Language) -> str | None:
     """
-    Looks for the correspondent checksum of a particular language to the given checksum (of the given language) the checksum if finds it, None otherwise
+    Looks for the correspondent checksum of a particular language to the given checksum (of the given language) returns the checksum if finds it, None otherwise
+
+    Example:
+        eng_checksum | fr_checksum
+        aaa          | aca
+        baa          | aba
+
+    ```py
+    find_correspondent_checksum(., "aaa", English, French) # returns "aca"
+    find_correspondent_checksum(., "aba", French, English) # returns "baa"
+    find_correspondent_checksum(., "ccc", French, English) # returns None
+    ```
     """
     if src_lang == tgt_lang:
         return None

--- a/trans_lib/translator.py
+++ b/trans_lib/translator.py
@@ -46,7 +46,7 @@ def _prepare_prompt_for_language(prompt_template: str, target_language: Language
 def _paste_vocabulary_into_prompt(prompt_template: str, vocabulary: str) -> str:
     return prompt_template.replace("[CUSTOM_VOCABULARY]", str(vocabulary))
 
-async def _ask_gemini_model(full_prompt_message: str, model_name: str = "gemini-2.0-flash") -> str:
+async def _ask_gemini_model(full_prompt_message: str, model_name: str = "gemini-2.5-flash-preview-05-20") -> str:
     """
     Asks the Gemini model for a translation.
     The default model_name is "gemini-2.0-flash"

--- a/trans_lib/translator_corrector.py
+++ b/trans_lib/translator_corrector.py
@@ -9,7 +9,7 @@ from trans_lib.trans_db import add_contents_to_db, do_translation_correspond_to_
 
 def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Language, new_translation: str, tgt_lang: Language) -> None:
     """
-    Corrects the translation pair by changing the target language translation result to the new given translation
+    Corrects the translation pair (in the correspondence database) by changing the target language translation result to the new given translation
     """
     _src_contents = read_contents_by_checksum_with_lang(root_path, src_checksum, src_lang)
     if _src_contents is None:

--- a/trans_lib/translator_corrector.py
+++ b/trans_lib/translator_corrector.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from trans_lib.enums import Language
 from trans_lib.errors import ChecksumNotFoundError
-from trans_lib.helpers import calculate_checksum
-from trans_lib.trans_db import add_contents_to_db, find_correspondent_checksum, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
+from trans_lib.trans_db import add_contents_to_db, do_translation_correspond_to_source, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
+
 
 
 def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Language, new_translation: str, tgt_lang: Language) -> None:
@@ -15,12 +15,9 @@ def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Lang
     if _src_contents is None:
         raise ChecksumNotFoundError
 
-    tgt_checksum = add_contents_to_db(root_path, new_translation, tgt_lang)
-
-    init_tgt_checksum = find_correspondent_checksum(root_path, src_checksum, src_lang, tgt_lang)
-
-    if tgt_checksum == init_tgt_checksum:
+    if do_translation_correspond_to_source(root_path, src_checksum, src_lang, new_translation, tgt_lang):
         return 
 
+    tgt_checksum = add_contents_to_db(root_path, new_translation, tgt_lang) 
     set_checksum_pair_to_correspondence_db(root_path, src_checksum, src_lang, tgt_checksum, tgt_lang)
     

--- a/trans_lib/translator_corrector.py
+++ b/trans_lib/translator_corrector.py
@@ -1,6 +1,8 @@
 
 
 from pathlib import Path
+
+from loguru import logger
 from trans_lib.enums import Language
 from trans_lib.errors import ChecksumNotFoundError
 from trans_lib.trans_db import add_contents_to_db, do_translation_correspond_to_source, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
@@ -13,11 +15,12 @@ def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Lang
     """
     _src_contents = read_contents_by_checksum_with_lang(root_path, src_checksum, src_lang)
     if _src_contents is None:
-        raise ChecksumNotFoundError
+        raise ChecksumNotFoundError(f"Given source checksum ({src_checksum}) isn't found in the database")
 
     if do_translation_correspond_to_source(root_path, src_checksum, src_lang, new_translation, tgt_lang):
         return 
 
     tgt_checksum = add_contents_to_db(root_path, new_translation, tgt_lang) 
+    logger.debug(f"Correcting: src({src_checksum}) and tgt({tgt_checksum})")
     set_checksum_pair_to_correspondence_db(root_path, src_checksum, src_lang, tgt_checksum, tgt_lang)
     

--- a/trans_lib/translator_corrector.py
+++ b/trans_lib/translator_corrector.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from trans_lib.enums import Language
 from trans_lib.errors import ChecksumNotFoundError
 from trans_lib.helpers import calculate_checksum
-from trans_lib.trans_db import add_contents_to_db, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
+from trans_lib.trans_db import add_contents_to_db, find_correspondent_checksum, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
 
 
 def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Language, new_translation: str, tgt_lang: Language) -> None:
@@ -16,6 +16,11 @@ def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Lang
         raise ChecksumNotFoundError
 
     tgt_checksum = add_contents_to_db(root_path, new_translation, tgt_lang)
+
+    init_tgt_checksum = find_correspondent_checksum(root_path, src_checksum, src_lang, tgt_lang)
+
+    if tgt_checksum == init_tgt_checksum:
+        return 
 
     set_checksum_pair_to_correspondence_db(root_path, src_checksum, src_lang, tgt_checksum, tgt_lang)
     

--- a/trans_lib/translator_corrector.py
+++ b/trans_lib/translator_corrector.py
@@ -1,0 +1,21 @@
+
+
+from pathlib import Path
+from trans_lib.enums import Language
+from trans_lib.errors import ChecksumNotFoundError
+from trans_lib.helpers import calculate_checksum
+from trans_lib.trans_db import add_contents_to_db, read_contents_by_checksum_with_lang, set_checksum_pair_to_correspondence_db
+
+
+def correct_chunk_translation(root_path: Path, src_checksum: str, src_lang: Language, new_translation: str, tgt_lang: Language) -> None:
+    """
+    Corrects the translation pair by changing the target language translation result to the new given translation
+    """
+    _src_contents = read_contents_by_checksum_with_lang(root_path, src_checksum, src_lang)
+    if _src_contents is None:
+        raise ChecksumNotFoundError
+
+    tgt_checksum = add_contents_to_db(root_path, new_translation, tgt_lang)
+
+    set_checksum_pair_to_correspondence_db(root_path, src_checksum, src_lang, tgt_checksum, tgt_lang)
+    

--- a/trans_lib/translator_retrieval.py
+++ b/trans_lib/translator_retrieval.py
@@ -16,12 +16,17 @@ async def translate_chunk_or_retrieve_from_db_async(root_path: Path, text_chunk:
     # TODO: verify that it doesn't exist in the db
     src_checksum = calculate_checksum(text_chunk)
     tgt_checksum = find_correspondent_checksum(root_path, src_checksum, source_language, target_language)
+    if src_checksum == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855":
+        logger.info(f"src: {src_checksum} | {tgt_checksum}")
     translated = "" 
+    found_in_db = False
+
     if tgt_checksum is not None: # if we found existing pair, try to extract translated contents
         logger.debug("Found the translation in the database")
+        found_in_db = True
         translated = read_contents_by_checksum_with_lang(root_path, tgt_checksum, target_language)
 
-    if ( translated == "" and text_chunk != "") or translated == None: # if the translation is empty, then we haven't found it and we should translate it
+    if ( translated == "" and not found_in_db) or translated == None: # if the translation is empty, then we haven't found it and we should translate it
         logger.debug("Didn't find the translation in the database, translate using LLM")
         prompt_for_lang = _prepare_prompt_for_language(prompt_placeholder, target_language)
         translated = await translate_chunk_with_prompt(prompt_for_lang, text_chunk)


### PR DESCRIPTION
# Editable Refinement Tracking

### 1. Motivation
* Track manual edits to translations and maintain their link to the original source content.

### 2. **Storing Original Source Checksum in Translated Chunk**

To allow users to **manually refine** translated content and still retain the link to the original, we store the original source checksum inside the translated chunk’s metadata. For example, in Jupyter notebooks:

```yml
---
  source_checksum: <checksum_en>
  ...
---
```

This enables reverse lookup: even after the translated content is edited (changing its checksum), we can retrieve the original source checksum and update the mapping:

translation_map.csv:
```csv
en,fr,de
<checksum_en>,<updated_checksum_fr>,<checksum_de>
```

### 3. **Refinement Workflow**

* During translation:

  * Compute checksum of source chunk.
  * Generate translation.
  * Save translation in `/database/<lang>/<checksum>`.
  * Store mapping in `translation_map.csv`.
  * Embed `source_checksum` in translated metadata.

* During refinement:

  * Edited translations are detected via content checksum mismatch.
  * The original `source_checksum` is read from metadata.
  * A new checksum is computed for the refined translation.
  * The mapping is updated: `source_checksum -> new_checksum`.

### Next Steps
- [x] Refining translation:
  - [x] add command to refine translation
  - [x] create new file with new checksum filename and contents
  - [x] update correspondence of checksum in the db
