### PR TITLE
LaTeX file chunking and translation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jupytext>=1.17.1",
     "loguru>=0.7.3",
     "pydantic>=2.11.5",
+    "pylatexenc>=2.10",
     "typer>=0.16.0",
     "types-pyyaml>=6.0.12.20250516",
 ]

--- a/trans_lib/constants.py
+++ b/trans_lib/constants.py
@@ -6,6 +6,7 @@ INTER_FILE_TRANSLATION_DELAY_SECONDS = 5
 DEFAULT_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/prompt4") # Make this configurable
 MARKDOWN_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/markdown_prompt")
 CODE_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/code_prompt")
+LATEX_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/prompt4")
 
 DB_DIR_NAME = "trans_git_db"
 CORRESPONDENCE_DB_NAME = "correspondence_db.csv"

--- a/trans_lib/constants.py
+++ b/trans_lib/constants.py
@@ -2,6 +2,10 @@ from pathlib import Path
 
 CONFIG_FILENAME = "trans_conf.json"
 INTER_FILE_TRANSLATION_DELAY_SECONDS = 5 
+
 DEFAULT_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/prompt4") # Make this configurable
+MARKDOWN_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/markdown_prompt")
+CODE_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/code_prompt")
+
 DB_DIR_NAME = "trans_git_db"
 CORRESPONDENCE_DB_NAME = "correspondence_db.csv"

--- a/trans_lib/doc_translator.py
+++ b/trans_lib/doc_translator.py
@@ -5,6 +5,7 @@ from .helpers import read_string_from_file, analyze_document_type
 from .errors import TranslationProcessError
 from .doc_translator_mod.notebook_file_translator import translate_notebook_async
 from pathlib import Path
+from .doc_translator_mod import latex_file_translator
 
 async def translate_file_async(source_path: Path, target_language: Language) -> str:
     """Reads a file, translates its content asynchronously, and returns the translated content."""
@@ -29,6 +30,9 @@ async def translate_file_to_file_async(
         if doc_type == DocumentType.Markdown or doc_type == DocumentType.JupyterNotebook:
             logger.trace("translate in this wat")
             await translate_notebook_async(root_path, source_path, source_language, target_path, target_language)
+        elif doc_type == DocumentType.LaTeX:
+            logger.trace("translate latex")
+            await latex_file_translator.translate_file_async(root_path, source_path, source_language, target_path, target_language)
         else:
             # TODO: proper chunking
             # TODO: DB saving

--- a/trans_lib/doc_translator_mod/latex_file_translator.py
+++ b/trans_lib/doc_translator_mod/latex_file_translator.py
@@ -1,0 +1,92 @@
+from asyncio import sleep
+import os
+from pathlib import Path
+
+from trans_lib.translator_retrieval import translate_chunk_or_retrieve_from_db_async
+from ..enums import Language
+from ..helpers import calculate_checksum, read_string_from_file
+from ..translator import _prepare_prompt_for_language, _ask_gemini_model, translate_chunk_with_prompt
+from ..constants import LATEX_PROMPT_PATH
+from pylatexenc.latexwalker import LatexWalker, LatexCharsNode, LatexMacroNode, LatexGroupNode, LatexEnvironmentNode
+import hashlib
+from loguru import logger
+
+ChunkData = dict[str, any]
+
+def _format_metadata_block(metadata: dict[str, str]) -> str:
+    """Formats a dictionary into a LaTeX comment metadata block."""
+    lines = ["% --- CHUNK_METADATA_START ---"]
+    for key, value in metadata.items():
+        lines.append(f"% {key}: {value}")
+    lines.append("% --- CHUNK_METADATA_END ---")
+    return "\n".join(lines) + "\n" # Add a newline at the end for separation
+
+def compile_latex_cells(cells: list[dict]) -> str:
+    """Takes a list of latex cells and compiles a final file contents and returns it in string format."""
+    res = ""
+    for cell in cells:
+        temp_res = _format_metadata_block(cell["metadata"])
+        temp_res += cell["source"]
+        res += temp_res
+    return res
+
+def get_latex_cells(source_file_path: Path) -> list[dict]:
+    """Get's a path to the file and returns it in the cells format"""
+    latex_document_string = ""
+    with open(source_file_path, "r") as f:
+        latex_document_string = f.read()
+    w = LatexWalker(latex_document_string)
+    (nodelist, _, _) = w.get_latex_nodes(pos=0)
+
+    cells = []
+    # dividing into cells
+    for node in nodelist:
+        contents = node.latex_verbatim()
+        cell = {
+                "metadata": {},
+                "source": contents
+                }
+        cells.append(cell)
+
+    return cells
+
+async def translate_file_async(root_path: Path, source_file_path: Path, source_language: Language, target_file_path: Path, target_language: Language) -> None:
+    """Handler for a latex file-to-file translation"""
+    cells = get_latex_cells(source_file_path)
+
+    for i in range(len(cells)):
+        cell = cells[i]
+        cells[i] = await translate_chunk_async(root_path, cell, source_language, target_language)
+
+    with open(target_file_path, "w") as f:
+        f.write(compile_latex_cells(cells))
+
+
+async def translate_chunk_async(root_path: Path, cell: dict, source_language: Language, target_language: Language) -> dict:
+   """Handler for a latex chunk translation"""
+   src_txt = cell["source"] 
+   logger.debug(f"{src_txt}")
+   checksum = calculate_checksum(src_txt)
+
+   cell["metadata"]["needs_review"] = "True"
+   cell["metadata"]["src_checksum"] = checksum
+
+   cell["source"] = await translate_any_chunk_async(root_path, src_txt, source_language, target_language)
+
+   return cell
+
+def get_latex_prompt_text() -> str:
+    """Reads latex prompt text from the configured path."""
+    try:
+        return read_string_from_file(LATEX_PROMPT_PATH)
+    except Exception as e:
+        print(f"Warning: Could not load default prompt from {LATEX_PROMPT_PATH}: {e}. Using a fallback.")
+        # Fallback prompt to avoid complete failure if file is missing
+        return "Translate the following document to [TARGET_LANGUAGE]. Maintain the original structure and formatting as much as possible. Only output the translated document text inside <output> tags.\nDocument text:\n"
+
+async def translate_any_chunk_async(root_path: Path, contents: str, source_language: Language, target_language: Language) -> str:
+    prompt = get_latex_prompt_text()
+    return await translate_chunk_or_retrieve_from_db_async(root_path, contents, source_language, target_language, prompt)
+
+
+

--- a/trans_lib/doc_translator_mod/notebook_file_translator.py
+++ b/trans_lib/doc_translator_mod/notebook_file_translator.py
@@ -6,6 +6,7 @@ from trans_lib.translator_retrieval import translate_chunk_or_retrieve_from_db_a
 from ..enums import Language
 from ..helpers import calculate_checksum, read_string_from_file
 from ..translator import _prepare_prompt_for_language, _ask_gemini_model, translate_chunk_with_prompt
+from ..constants import MARKDOWN_PROMPT_PATH, CODE_PROMPT_PATH
 import jupytext
 import hashlib
 from loguru import logger
@@ -33,8 +34,6 @@ async def translate_jupyter_cell_async(root_path: Path, cell: dict, source_langu
 
     return cell
 
-MARKDOWN_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/markdown_prompt")
-CODE_PROMPT_PATH = Path("/Users/dobbikov/Desktop/stage/prompts/doc_specific/code_prompt")
 
 def get_markdown_prompt_text() -> str:
     """Reads the markdown prompt text from the configured path."""

--- a/trans_lib/project_manager.py
+++ b/trans_lib/project_manager.py
@@ -442,6 +442,7 @@ def load_project(path_str: str) -> Project:
         config_model = load_project_config(config_file_path)
         project = Project(project_root, config_model)
         print(f"Project '{project.config.name}' loaded from {project_root}")
+        project.update_project_structure()
         return project
     except ConfigLoadError as e:
         raise LoadProjectError(f"Failed to load project configuration: {e}", e)

--- a/uv.lock
+++ b/uv.lock
@@ -391,6 +391,12 @@ wheels = [
 ]
 
 [[package]]
+name = "pylatexenc"
+version = "2.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
+
+[[package]]
 name = "pywin32"
 version = "310"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +548,7 @@ dependencies = [
     { name = "jupytext" },
     { name = "loguru" },
     { name = "pydantic" },
+    { name = "pylatexenc" },
     { name = "typer" },
     { name = "types-pyyaml" },
 ]
@@ -553,6 +560,7 @@ requires-dist = [
     { name = "jupytext", specifier = ">=1.17.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pylatexenc", specifier = ">=2.10" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
 ]


### PR DESCRIPTION
# LaTeX chunking

In order to translate `latex` files efficiently we need to properly divide into chunks. The inspiration for the chunking right now is the `jupyter tranlsator` module. 

For proper LaTeX processing the `pylatexenc` library is used. Currently, the library divides the contents by: known latex commands and `\begin` command. The contents inside the chunks are not divided into more chunks (for now). 

## Current issues: 
- Unknown commands are divided too stupidly:
For example, the next command:
```tex
\newtheorem*{remarque}{Remark}
```

Is divided into the next chunks:
```tex
\newtheorem
% --- CHUNK_METADATA_START ---
% needs_review: True
% src_checksum: 684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1
% --- CHUNK_METADATA_END ---
*
% --- CHUNK_METADATA_START ---
% needs_review: True
% src_checksum: 8b56de415f9db116485202f8235d82f566945d2a8f3428104d04574a543ffcdb
% --- CHUNK_METADATA_END ---
{remarque}
% --- CHUNK_METADATA_START ---
% needs_review: True
% src_checksum: 6f2667a8d4f4378d1efc3eca52b1d0fcb71907d929fe1c237e86dfd709cb87d4
% --- CHUNK_METADATA_END ---
{Remark}
```

- If the contents inside begin are too huge, the model can be overwhelmed:
For example, if the document contains `\begin{document}`
The entire contents of the document will be considered as one chunk:

```tex
\begin{document}
    Bonjour tout le monde!

    Je suis tres heureux de vous voir ici aujourdhui!
\end{document}
```

Is chunked in the next way:
```tex
% --- CHUNK_METADATA_START ---
% needs_review: True
% src_checksum: 29d1eb452dbff5f2d115f33d9ae93e757d0ee685a8b9682bc7936a33d60d9ce1
% --- CHUNK_METADATA_END ---
\begin{document}
    Hello everyone!

    I am very happy to see you here today!
\end{document}
```

## Todo:
- [ ] explore the better unknown command chunking
- [ ] divide huge chunks into more chunks
- [ ] dont' translate white spaces
- [ ] correcting translated `latex` files