### PR TITLE
Reworking app files logic

### DIFF
--- a/docs/tool-profound-explanation.md
+++ b/docs/tool-profound-explanation.md
@@ -71,7 +71,7 @@ analysis_translation_proj/
 │   │   └── ...
 │   └── bib/
 │       └── bib.tex
-├── trans_git_db/
+├── .trans_git/
     ├── trans_conf.json
     └── trans_git_db/
         └── ...
@@ -96,7 +96,7 @@ analysis_translation_proj/
 │   │   └── ...
 │   └── bib/
 │       └── bib.tex
-├── trans_git_db/
+├── .trans_git/
     ├── trans_conf.json
     └── trans_git_db/
         └── ...

--- a/docs/tool-profound-explanation.md
+++ b/docs/tool-profound-explanation.md
@@ -22,9 +22,9 @@ the information about your file structure, languages and translation database.
 
 The project behaves similarly to the git. There's always a root directory that
 you must be in, where you'll initialize the translation project. The directory
-contains project's config, translation database and the files that are
-"tracked", in our case the files that are synced and translated across the
-languages.
+contains project's config in the _dot_ directory dedicated to this tool,
+translation database and the files that are "tracked", in our case the files
+that are synced and translated across the languages.
 
 > Note: don't confuse your writing project, for example: LaTeX project and
 > translation project. Your "writing project's" root directory must be placed
@@ -71,9 +71,10 @@ analysis_translation_proj/
 │   │   └── ...
 │   └── bib/
 │       └── bib.tex
-├── trans_conf.json
 ├── trans_git_db/
-    └── ...
+    ├── trans_conf.json
+    └── trans_git_db/
+        └── ...
 ```
 
 And after translation into Ukrainian:
@@ -95,17 +96,18 @@ analysis_translation_proj/
 │   │   └── ...
 │   └── bib/
 │       └── bib.tex
-├── trans_conf.json
 ├── trans_git_db/
-    └── ...
+    ├── trans_conf.json
+    └── trans_git_db/
+        └── ...
 ```
 
 ## Project initialization and required settings
-When you initialize a project the `trans_conf.json` config file is created that stores:
+When you initialize a project the `.trans_git` directory is created that stores `trans_conf.json` config. This config stores:
 - project's name
 - source and target languages
 - directories that correspond to the source and target languages
-- the files structure 
+- files that must be translated
 - and additional settings 
 
 However, when you initialize a project, you define your intentions but it is

--- a/src/trans_lib/constants.py
+++ b/src/trans_lib/constants.py
@@ -5,3 +5,6 @@ INTER_FILE_TRANSLATION_DELAY_SECONDS = 5
 
 DB_DIR_NAME = "trans_git_db"
 CORRESPONDENCE_DB_NAME = "correspondence_db.csv"
+
+APP_NAME = "trans_git"
+CONF_DIR = f".{APP_NAME}" 

--- a/src/trans_lib/constants.py
+++ b/src/trans_lib/constants.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 CONFIG_FILENAME = "trans_conf.json"
 INTER_FILE_TRANSLATION_DELAY_SECONDS = 5 

--- a/src/trans_lib/doc_corrector.py
+++ b/src/trans_lib/doc_corrector.py
@@ -1,5 +1,4 @@
 
-from logging import root
 from pathlib import Path
 
 import jupytext

--- a/src/trans_lib/doc_translator.py
+++ b/src/trans_lib/doc_translator.py
@@ -1,6 +1,5 @@
 from loguru import logger
 
-from trans_lib import vocab_list
 from trans_lib.vocab_list import VocabList
 from .enums import DocumentType, Language
 from .translator import translate_contents_async

--- a/src/trans_lib/doc_translator_mod/latex_chunker.py
+++ b/src/trans_lib/doc_translator_mod/latex_chunker.py
@@ -1,5 +1,5 @@
 import re
-from pylatexenc.latexwalker import LatexWalker, LatexCharsNode, LatexMacroNode, LatexGroupNode, LatexEnvironmentNode, LatexCommentNode, LatexMathNode, LatexSpecialsNode
+from pylatexenc.latexwalker import LatexWalker, LatexMacroNode, LatexEnvironmentNode
 from typing import Any, Optional
 from pathlib import Path
 
@@ -32,9 +32,9 @@ def _chunk_nodelist(
     Recursively chunks a given pylatexenc nodelist, respecting full spans of
     environments and macros with arguments.
     `base_start_offset` is the starting character offset of the segment of the original
-    string that this nodelist represents (e.g., the content inside \begin{document}).
+    string that this nodelist represents (e.g., the content inside \\begin{document}).
     `end_offset_limit` is the character offset where this nodelist's content ends
-    (e.g., just before \end{document} macro).
+    (e.g., just before \\end{document} macro).
     """
     chunks_raw: list[str] = []
     current_chunk_start_pos = base_start_offset
@@ -70,7 +70,8 @@ def _chunk_nodelist(
                 between_nodes = []
                 
             chunk_content = original_latex_string[node_full_span_start:node_full_span_end].strip()
-            if chunk_content: chunks_raw.append(chunk_content)
+            if chunk_content: 
+                chunks_raw.append(chunk_content)
             current_chunk_start_pos = node_full_span_end
             i += 1
             
@@ -80,7 +81,8 @@ def _chunk_nodelist(
                 between_nodes = []
                 
             chunk_content = original_latex_string[node_full_span_start:node_full_span_end].strip()
-            if chunk_content: chunks_raw.append(chunk_content)
+            if chunk_content: 
+                chunks_raw.append(chunk_content)
             current_chunk_start_pos = node_full_span_end
             i += 1
 

--- a/src/trans_lib/doc_translator_mod/latex_file_translator.py
+++ b/src/trans_lib/doc_translator_mod/latex_file_translator.py
@@ -1,15 +1,11 @@
-from asyncio import sleep
 from ..prompts import prompt4
-import os
 from pathlib import Path
 
 from trans_lib.doc_translator_mod.latex_chunker import split_latex_document_into_chunks
 from trans_lib.translator_retrieval import translate_chunk_or_retrieve_from_db_async
 from trans_lib.vocab_list import VocabList
 from ..enums import Language
-from ..helpers import calculate_checksum, read_string_from_file
-from ..translator import _prepare_prompt_for_language, _ask_gemini_model, translate_chunk_with_prompt
-import hashlib
+from ..helpers import calculate_checksum
 from loguru import logger
 
 

--- a/src/trans_lib/doc_translator_mod/notebook_file_translator.py
+++ b/src/trans_lib/doc_translator_mod/notebook_file_translator.py
@@ -1,17 +1,11 @@
-from asyncio import sleep
-import os
 from ..prompts import prompt_jupyter_code, prompt_jupyter_md 
 from pathlib import Path
 
-from trans_lib import vocab_list
 from trans_lib.translator_retrieval import translate_chunk_or_retrieve_from_db_async
 from trans_lib.vocab_list import VocabList
 from ..enums import Language
-from ..helpers import calculate_checksum, read_string_from_file
-from ..translator import _prepare_prompt_for_language, _ask_gemini_model, translate_chunk_with_prompt
+from ..helpers import calculate_checksum
 import jupytext
-import hashlib
-from loguru import logger
 
 async def translate_notebook_async(root_path: Path, source_file_path: Path, source_language: Language, target_file_path: Path, target_language: Language, vocab_list: VocabList | None) -> None:
     nb = jupytext.read(source_file_path)

--- a/src/trans_lib/helpers.py
+++ b/src/trans_lib/helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Iterable
 import hashlib
 
+from trans_lib.constants import CONF_DIR
 from trans_lib.enums import DocumentType
 
 def calculate_checksum(contents: str) -> str:
@@ -19,6 +20,26 @@ def ensure_dir_exists(path: Path) -> None:
     if not path.is_dir():
         os.mkdir(path)
         return
+
+def find_dir_upwards(start_path: Path, dir_name: str) -> Optional[Path]:
+    """
+    Search the given directory and each parent directory for `dir_name`.
+    Returns the full path to the first match, or `None` if nothing is found.
+    """
+    current_dir = start_path.resolve()
+    if not current_dir.is_dir():
+        current_dir = current_dir.parent
+
+    while current_dir:
+        candidate = current_dir / dir_name
+        if candidate.is_dir():
+            return candidate
+        
+        if current_dir == current_dir.parent:  # Reached filesystem root
+            break
+        current_dir = current_dir.parent
+    
+    return None
 
 def find_file_upwards(start_path: Path, file_name: str) -> Optional[Path]:
     """
@@ -216,3 +237,6 @@ def analyze_document_type(path: Path) -> DocumentType:
             return DocumentType.JupyterNotebook
         return DocumentType.Markdown
     return DocumentType.Other
+
+def get_config_dir_from_root(root_path: Path) -> Path:
+    return root_path / CONF_DIR

--- a/src/trans_lib/project_manager.py
+++ b/src/trans_lib/project_manager.py
@@ -479,7 +479,7 @@ def init_project(project_name: str, root_dir_str: str) -> Project:
         # Create a Project instance with an empty config, then save it.
         project = Project._create_new_for_init(project_name, abs_root_path)
         project.save_config() # This writes the initial trans_conf.json
-        print(f"Project '{project_name}' initialized at {abs_root_path}")
+        print(f"{CONF_DIR} directory has been successfully created!")
         return project
     except ConfigWriteError as e:
         raise InitProjectError(f"Failed to write initial config file: {e}", e)

--- a/src/trans_lib/translator.py
+++ b/src/trans_lib/translator.py
@@ -1,7 +1,5 @@
 import asyncio
 import os
-from pathlib import Path
-from typing import Optional
 
 from google import genai
 from google.genai import types as g_types
@@ -12,7 +10,7 @@ from .constants import INTER_FILE_TRANSLATION_DELAY_SECONDS
 from .prompts import prompt4
 
 from .enums import Language
-from .helpers import divide_into_chunks, extract_translated_from_response, read_string_from_file
+from .helpers import divide_into_chunks, extract_translated_from_response
 from .errors import TranslationProcessError
 import requests
 

--- a/src/trans_lib/translator_retrieval.py
+++ b/src/trans_lib/translator_retrieval.py
@@ -35,7 +35,7 @@ async def translate_chunk_or_retrieve_from_db_async(root_path: Path, text_chunk:
         tgt_checksum = add_contents_to_db(root_path, translated, target_language) 
         set_checksum_pair_to_correspondence_db(root_path, src_checksum, source_language, tgt_checksum, target_language)
 
-    if ( translated == "" and not found_in_db) or translated == None: # if the translation is empty, then we haven't found it and we should translate it
+    if ( translated == "" and not found_in_db) or translated is None: # if the translation is empty, then we haven't found it and we should translate it
         logger.debug("Didn't find the translation in the database, translate using LLM")
         prompt_for_lang = _prepare_prompt_for_language(prompt_placeholder, target_language)
         prompt_for_lang = _prepare_prompt_for_vocab_list(prompt_for_lang, vocab_list)


### PR DESCRIPTION
Currently, our config is stored in the root directory and it contains the file/directory structure of source directory as well as target language directories. The directory for the translation database is also stored in the _root_ directory of the project. 

As our library is inspired by _git_, the next changes are suggested:
- create one _config_ directory named `.trans_git`
- store the config file in this new directory
- store only translatable files in the config
- store _translation database_ directory in the `.trans_git` directory

This will help to store all the app-specific files and directories in one place.

Before merging this pull request, do #29 ! (Done)