### PR TITLE
Docs/markdown-Formatting-fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Before contributing, make sure to read [the profound explanation](./docs/tool-profound-explanation.md) in order to understand how the tool work and its idea. 
+Before contributing, make sure to read [the profound explanation](./docs/tool-profound-explanation.md) in order to understand how the tool work and its idea.
 
 Each pull request must contain the following sections:
+
 - **Motivation** - describes why this pull request is created in the first place (can be one sentence short).
 - **Explanation** - explains what does the pull request change in the project's code base or architecture.
 
-If you want to contribute but don't know what to start with, read the ToDo section in the [README](README.md). 
+If you want to contribute but don't know what to start with, read the ToDo section in the [README](README.md).
 
 All pull requests, ideas and suggestions are welcome!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Translate directory library
+
 A library to manage the translation text writing projects (e.g: LaTeX,
 Markdown, Jupyter, MyST, Typst). The library is aimed to simplify and automate
 the translation process and compiling of the translated version of the documents.
 
-**Important**
+## **Important**
+
 > The library is still in an early phase of development and may have bugs and unimplemented features
 
 ## Features
+
 - [x] Project creation
 - [x] Source language and the source folder to translate setting
 - [x] Target language addition
@@ -18,13 +21,16 @@ the translation process and compiling of the translated version of the documents
 The profound explanation of the logic and algorithms of the tool can be found [here](./docs/tool-profound-explanation.md)
 
 ## Installation
+
 ### For in-project library usage
+
 1. Clone the repo: `git clone https://github.com/DobbiKov/translate-dir-lib`
 2. Enter to your project where you want to use this library (`cd <your_project_path>`)
 3. Install the library as a dependency using `pip`: `pip install <path_to_the_library_directory>`
 4. Enjoy!
 
 ### For the library development and contribution uses
+
 1. Ensure you have [uv](https://docs.astral.sh/uv/#__tabbed_1_1) tool installed
    (visit their site for the installation guide)
 2. Clone the repo: `git clone https://github.com/DobbiKov/translate-dir-lib`
@@ -37,11 +43,13 @@ The profound explanation of the logic and algorithms of the tool can be found [h
 The documentation for the library can be found [here](./docs/main.md)
 
 ## ToDo
+
 - [ ] Fix paragraph and list handling in MyST parsing.
 
 ## 📚 Citation
 
 If you use this software in your research or writing, please cite it as follows:
+
 ```bib
 @software{korotenko-sci-trans-git,
     author = {Yehor Korotenko},
@@ -54,8 +62,8 @@ If you use this software in your research or writing, please cite it as follows:
 }
 ```
 
+## Contributing
 
-## Contributing 
 The suggestions and pull requests are welcome. Visit the issues pages as well
 as the project's [main page](https://github.com/DobbiKov/sci-trans-git) and the
 [shared document](https://codimd.math.cnrs.fr/sUW9PQ1tTLWcR98UjLHLpw) in order

--- a/docs/main.md
+++ b/docs/main.md
@@ -2,5 +2,4 @@
 
 Coming soon...
 
-
 If you really need the docs, please email me: [dobbikov@gmail.com](mailto:dobbikov@gmail.com).

--- a/docs/tool-profound-explanation.md
+++ b/docs/tool-profound-explanation.md
@@ -1,24 +1,31 @@
 # The profound explanation of the tool
-This page contains the profound overview and explanation of the architecture, algorithms and ideology of the library and explain all its features.
+
+This page contains the profound overview and explanation of the architecture,
+algorithms and ideology of the library and explain all its features.
 
 ## Table of Contents
-- [Main Unit: Project](#main-unit-project)
-- [Project initialization and required settings](#project-initialization-and-required-settings)
-- [Two types of files](#two-types-of-files)
-- [Syncing vs Translating](#syncing-vs-translating)
+
+- [The profound explanation of the tool](#the-profound-explanation-of-the-tool)
+  - [Table of Contents](#table-of-contents)
+  - [Main Unit: Project](#main-unit-project)
+  - [Project initialization and required settings](#project-initialization-and-required-settings)
+    - [Important notes](#important-notes)
+  - [Two types of files](#two-types-of-files)
+  - [Syncing vs Translating](#syncing-vs-translating)
     - [Syncing](#syncing)
     - [Translating](#translating)
-    - [Difference](#difference) 
-- [Translation algorithm](#translation-algorithm)
-- [Correcting](#correcting)
-- [Translation Database](#translation-database)
-    - [Structure](#strucute)
+    - [Difference](#difference)
+  - [Translation algorithm](#translation-algorithm)
+  - [Correcting](#correcting)
+  - [Translation Database](#translation-database)
+    - [Structure](#structure)
     - [Text to checksum DB](#text-to-checksum-db)
     - [Correspondence DB](#correspondence-db)
 
 ## Main Unit: Project
-The main unit of the library is called **project**. The project contains all
-the information about your file structure, languages and translation database.
+
+The main unit of the library is called **project**. The project contains all the
+information about your file structure, languages and translation database.
 
 The project behaves similarly to the git. There's always a root directory that
 you must be in, where you'll initialize the translation project. The directory
@@ -27,11 +34,12 @@ translation database and the files that are "tracked", in our case the files
 that are synced and translated across the languages.
 
 > Note: don't confuse your writing project, for example: LaTeX project and
-> translation project. Your "writing project's" root directory must be placed
-> in the root directory of the translation project.
+> translation project. Your "writing project's" root directory must be placed in
+> the root directory of the translation project.
 
-For example:
-Let's assume that we have a LaTeX project in the directory called `analysis_notes` that has the next structure
+For example: Let's assume that we have a LaTeX project in the directory called
+`analysis_notes` that has the next structure
+
 ```
 analysis_notes/
 ├── main.tex
@@ -43,8 +51,8 @@ analysis_notes/
     └── bib.tex
 ```
 
-Then, if we want to create a translation project using this CLI, then we need
-to move to the directory of our choice or create one, here:
+Then, if we want to create a translation project using this CLI, then we need to
+move to the directory of our choice or create one, here:
 `analysis_translation_proj` and put the `analysis_notes` directory there:
 
 ```
@@ -59,7 +67,8 @@ analysis_translation_proj/
         └── bib.tex
 ```
 
-Then, when we will initialize our translation project it will have the next structure:
+Then, when we will initialize our translation project it will have the next
+structure:
 
 ```
 analysis_translation_proj/
@@ -78,6 +87,7 @@ analysis_translation_proj/
 ```
 
 And after translation into Ukrainian:
+
 ```
 analysis_translation_proj/
 ├── analysis_notes/
@@ -103,68 +113,82 @@ analysis_translation_proj/
 ```
 
 ## Project initialization and required settings
-When you initialize a project the `.translate_dir` directory is created that stores `config.json` config. This config stores:
+
+When you initialize a project the `.translate_dir` directory is created that
+stores `config.json` config. This config stores:
+
 - project's name
 - source and target languages
 - directories that correspond to the source and target languages
 - files that must be translated
-- and additional settings 
+- and additional settings
 
-However, when you initialize a project, you define your intentions but it is
-not sufficient yet to translate any files.
+However, when you initialize a project, you define your intentions but it is not
+sufficient yet to translate any files.
 
-Firstly, you must set the **source directory** and a language that corresponds to
-that source directory. Only the files from the set source directory will be
+Firstly, you must set the **source directory** and a language that corresponds
+to that source directory. Only the files from the set source directory will be
 able to be translated, you can't specify any files from other directories that
 are not children of the source directory to be translatable even if those files
 are located in the root directory of the project.
 
 Secondly, you must set the target languages different from the source language.
 The setting of a target language will create a directory in the root of the
-project that will have as a name: the name of the project and an appropriate language suffix.
-Example: The addition of the French language in the project named
-`analysis_course` will produce the directory with a name `analysis_course_fr`.
+project that will have as a name: the name of the project and an appropriate
+language suffix. Example: The addition of the French language in the project
+named `analysis_course` will produce the directory with a name
+`analysis_course_fr`.
 
 This directory will have the copy of the source directory with translated files.
 
 ### Important notes
-- The source directory can be reset, i.e you can set another directory as a source one using the same `set-source command`.
-- The target languages can be removed using `remove-target` command (in CLI), or `remove_target_language` method in the library.
+
+- The source directory can be reset, i.e you can set another directory as a
+  source one using the same `set-source command`.
+- The target languages can be removed using `remove-target` command (in CLI), or
+  `remove_target_language` method in the library.
 
 ## Two types of files
-All the files in the source directory are considered as *untranslatable* by
+
+All the files in the source directory are considered as _untranslatable_ by
 default. It means that those files won't be translated and will be copied when
 `sync` command is used.
 
-You can mark any file in the source directory as *translatable*, then such file
+You can mark any file in the source directory as _translatable_, then such file
 won't be copied by `sync` command and will be able to be translated using the
 appropriate command.
 
 ## Syncing vs Translating
+
 ### Syncing
-When `sync` command is used, all the *untranslatable* files from the source
+
+When `sync` command is used, all the _untranslatable_ files from the source
 directory are copied to the target language directories. An example of such
 files are images, figures or bibliography.
 
 The goal of this functionality is to reproduce your "writing" project's
-structure in order to simplify the compilation process. That is to say, when
-you translate your project and use `sync` command, you can compile it without
-any additional actions required.
+structure in order to simplify the compilation process. That is to say, when you
+translate your project and use `sync` command, you can compile it without any
+additional actions required.
 
-> Note: the `sync` command doesn't copy the files that are marked as *translatable*.
+> Note: the `sync` command doesn't copy the files that are marked as
+> _translatable_.
 
 ### Translating
+
 Translating reads the files in the source directory that are marked as
-*translatable*, translates them and writes to the appropriate target language
+_translatable_, translates them and writes to the appropriate target language
 directories. During the translation process, the files that are _not_ marked as
 _translatable_ won't be copied to the target directories.
 
 ### Difference
+
 The syncing _copies_ only the _untranslatable_ files and doesn't touch
 _translatable_ ones. Translating translates the files and put them into
 appropriate directories.
 
 ## Translation algorithm
+
 The core idea of the algorithm of the algorithm is read a file, divide it into
 _chunks_ (sometimes called _cells_ here) and pass to an LLM (currently _gemini_
 models from google) with a big prompt that asks a model translate a chunk and
@@ -174,16 +198,19 @@ written to the output file.
 
 After the translation, some metadata is set for each chunk in the output file.
 Such metadata may be:
-- source checksum that serves to identify the source text that has been translated
-- _needs\_review_ tag that alerts the user that a particular chunk has been
+
+- source checksum that serves to identify the source text that has been
+  translated
+- _needs_review_ tag that alerts the user that a particular chunk has been
   translated by machine but wasn't verified by human.
 
-The translation command may also take an optional parameter that is a
-vocabulary list. That list contains pairs of a word or phrase on a source
-language and it's translation on the target one. That vocabulary that is passed
-to the LLM in order to improve it's translation quality.
+The translation command may also take an optional parameter that is a vocabulary
+list. That list contains pairs of a word or phrase on a source language and it's
+translation on the target one. That vocabulary that is passed to the LLM in
+order to improve it's translation quality.
 
 Current version of the library supports the next services:
+
 - OpenAI
 - Anthropic
 - Google
@@ -198,6 +225,7 @@ When translating, an environment variable `LLM_API_KEY` must be set accordingly
 to the service you use.
 
 ## Correcting
+
 After the translation a user may want to correct or edit the translated files.
 These changes are logically should be saved in order to not lose those changes.
 Thus, when the correction command is called, it reads each translated chunk in
@@ -206,12 +234,13 @@ it figures out that the translation has been changed by user it updates it in
 the database.
 
 ## Translation Database
+
 Translation database is aimed to store translation pairs in order to avoid
 retranslation of the chunks that have already been translated previously and
-track changes and edits in the source project and the translated versions of
-it.
+track changes and edits in the source project and the translated versions of it.
 
 ### Structure
+
 The database is presented in the `translate_db` directory that is stored in the
 root directory of the project. This folder has the next structure:
 
@@ -225,16 +254,19 @@ translate_db/
 ```
 
 and consists of the next parts:
+
 - Text to checksum DB
 - correspondence DB
 
 ### Text to checksum DB
+
 This part of the database is represented by the `<lang_*>` folders that store
 files that has any text (usually the text of the chunks from the files) and the
 checksum of the contents of the file as a name of the file. This system allows
 the storage of the chunk contents, source retrieval and updates comparison.
 
 Example of such structure:
+
 ```
 translate_db/
 ├── English/
@@ -247,11 +279,13 @@ translate_db/
 ```
 
 ### Correspondence DB
+
 The correspondence database is represented by the `correspondence_db.csv` file
 that stores in each row the checksum of at least two languages that the source
 contents correspond to the translated contents.
 
 Example:
+
 ```
 English,French
 <checksum1_en>, <checksum1_fr>


### PR DESCRIPTION
When Fixing another bug , found formatting issues(not that of a issue) in markdown files. So I thought it would be great to fix them now.

Applied Prettier formatting to fix multiple markdown lint issues:

- Added proper spacing after headers and sections
- Fixed line wrapping for better readability (80 chars for prose)
- Corrected table of contents indentation and structure
- Standardized italic text formatting (*text* -> _text_)
- Added blank lines before code blocks and lists
- Fixed inconsistent spacing around bullet points
- Improved overall markdown structure and consistency

Files updated:
- docs/tool-profound-explanation.md
- docs/main.md
- README.md
- CONTRIBUTING.md

All markdown now follows standard formatting conventions.